### PR TITLE
정렬 기능 구현

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -75,7 +75,7 @@ const TabularRow = styled.tr`
 `;
 
 const TabularHeader = styled.th<{ clickable: boolean }>`
-  min-width: 200px;
+  width: 200px;
   padding: 10px;
   background: #eaeaea;
   cursor: ${(props) => (props.clickable ? 'pointer' : 'auto')};
@@ -86,8 +86,12 @@ const TabularHeader = styled.th<{ clickable: boolean }>`
 `;
 
 const TabularData = styled.td`
+  max-width: 200px;
   border-bottom: 1px solid #eaeaea;
   padding: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export default Table;

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,4 +1,19 @@
 /** country 리스트의 첫 번째 페이지 넘버 */
 export const INITIAL_PAGE = 1;
+
 /** 한 번에 표시할 country 리스트 개수 */
-export const COUNTRY_LIMIT = 30;
+export const COUNTRY_LIMIT = 60;
+
+/** country를 정렬하는 순서 */
+export enum SortOrder {
+  Default,
+  ASC,
+  DESC,
+}
+
+/** 정렬 순서 텍스트 맵핑 객체 */
+export const SORT_ORDER_TEXT: { [key in SortOrder]: string } = {
+  [SortOrder.Default]: '',
+  [SortOrder.ASC]: '(오름차순)',
+  [SortOrder.DESC]: '(내림차순)',
+};

--- a/src/containers/CountryTable.tsx
+++ b/src/containers/CountryTable.tsx
@@ -1,48 +1,71 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Table from '../components/Table';
-import { actions } from '../state';
-import { countriesSelector } from '../state/selector';
+import Table, { TableColumn } from '../components/Table';
+import { SORT_ORDER_TEXT } from '../constant';
+import { actions, SortOptions } from '../state';
+import {
+  renderableCountriesSelector,
+  sortOptionsSelector,
+} from '../state/selector';
 
-const { useEffect } = React;
+const { useEffect, useCallback } = React;
 
 /** 국가 정보를 나타내는 컴포넌트 */
 const CountryTable = (): JSX.Element => {
-  const countries = useSelector(countriesSelector);
+  const dispatch = useDispatch();
+  const countries = useSelector(renderableCountriesSelector);
+  const sortOptions = useSelector(sortOptionsSelector);
+
+  const onColumnClick = useCallback(
+    (column: TableColumn) => dispatch(actions.sortCountries(column.dataIndex)),
+    [dispatch]
+  );
+
   const columms = [
     {
-      title: 'name',
+      title: getColumnTitle('name', sortOptions),
       dataIndex: 'name',
+      onClick: onColumnClick,
     },
     {
-      title: 'alpha2Code',
+      title: getColumnTitle('alpha2Code', sortOptions),
       dataIndex: 'alpha2Code',
+      onClick: onColumnClick,
     },
     {
-      title: 'callingCodes',
+      title: getColumnTitle('callingCodes', sortOptions),
       dataIndex: 'callingCodes',
       render: (codes: unknown) => {
         if (Array.isArray(codes)) {
           return codes.join(', ');
         }
       },
+      onClick: onColumnClick,
     },
     {
-      title: 'capital',
+      title: getColumnTitle('capital', sortOptions),
       dataIndex: 'capital',
+      onClick: onColumnClick,
     },
     {
-      title: 'region',
+      title: getColumnTitle('region', sortOptions),
       dataIndex: 'region',
+      onClick: onColumnClick,
     },
   ];
 
-  const dispatch = useDispatch();
   useEffect(() => {
     dispatch(actions.fetchCountries());
   }, [dispatch]);
 
   return <Table columns={columms} dataSource={countries} />;
 };
+
+/** 정렬 정보를 담은 colume 이름을 반환한다 */
+function getColumnTitle(title: string, sortOptions: SortOptions): string {
+  const sortInfo =
+    sortOptions.key === title ? SORT_ORDER_TEXT[sortOptions.sortOrder] : '';
+  return title + sortInfo;
+}
 
 export default CountryTable;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,10 +1,19 @@
 import { createAction, createReducer } from '@reduxjs/toolkit';
-import { INITIAL_PAGE } from '../constant';
+import { INITIAL_PAGE, SortOrder } from '../constant';
 import { Country } from '../types';
+import { getEnumLength } from '../utils/enum';
+
+export interface SortOptions {
+  /** 정렬 기준이 되는 country의 속성 */
+  key: string;
+  /** 정렬 순서 */
+  sortOrder: keyof { [K in SortOrder]: never };
+}
 
 interface State {
   countries: Country[];
   currentPage: number;
+  sortOptions: SortOptions;
 }
 
 export const actions = {
@@ -12,12 +21,19 @@ export const actions = {
     payload: countries,
   })),
   increaseCurrentPage: createAction('increaseCurrentPage'),
+  sortCountries: createAction('sortCountries', (key: string) => ({
+    payload: key,
+  })),
   fetchCountries: createAction('fetchCountries'),
 };
 
 const INITIAL_STATE: State = {
   countries: [],
   currentPage: INITIAL_PAGE,
+  sortOptions: {
+    key: 'name',
+    sortOrder: SortOrder.Default,
+  },
 };
 
 const reducer = createReducer(INITIAL_STATE, (builder) => {
@@ -28,6 +44,20 @@ const reducer = createReducer(INITIAL_STATE, (builder) => {
     })
     .addCase(actions.increaseCurrentPage, (state) => {
       state.currentPage += 1;
+    })
+    .addCase(actions.sortCountries, (state, action) => {
+      const key = action.payload;
+      const { sortOptions } = state;
+
+      if (sortOptions.key === key) {
+        sortOptions.sortOrder =
+          (sortOptions.sortOrder + 1) % getEnumLength(SortOrder);
+      } else {
+        sortOptions.key = key;
+        sortOptions.sortOrder = SortOrder.ASC;
+      }
+
+      state.currentPage = INITIAL_PAGE;
     });
 });
 

--- a/src/state/selector.ts
+++ b/src/state/selector.ts
@@ -1,27 +1,84 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { COUNTRY_LIMIT } from '../constant';
+import { COUNTRY_LIMIT, SortOrder } from '../constant';
 import { RootState } from '../store';
+import { Country } from '../types';
 
+const countriesSelector = (state: RootState) => state.countries;
 const currentPageSelector = (state: RootState) => state.currentPage;
+export const sortOptionsSelector = (state: RootState) => state.sortOptions;
 
-/** 모든 국가 정보 객체를 배열로 반환하는 selector */
-const allCountriesSelector = (state: RootState) => {
-  const countries = state.countries;
-  return countries.map((country) => ({ ...country, key: country.alpha2Code }));
-};
+/** 기본 또는 오름차순 또는 내림차순으로 정렬된 국가 배열을 반환하는 selector */
+const sortedCountriesSelector = createSelector(
+  countriesSelector,
+  sortOptionsSelector,
+  (countries, sortOptions) => {
+    const { key, sortOrder } = sortOptions;
+    const getSortValue = (country: Country) => {
+      assertIsValidCountryKey(country, key);
+      const sortValue = country[key];
+      return Array.isArray(sortValue) ? sortValue.length : sortValue;
+    };
+
+    switch (sortOrder) {
+      case SortOrder.Default:
+        return [...countries];
+      case SortOrder.ASC:
+        return [...countries].sort((a, b) => {
+          const valueA = getSortValue(a);
+          const valueB = getSortValue(b);
+
+          if (typeof valueA === 'number' && typeof valueB === 'number') {
+            return valueA - valueB;
+          } else if (typeof valueA === 'string' && typeof valueB === 'string') {
+            return valueA === valueB ? 0 : valueA < valueB ? -1 : 1;
+          } else {
+            throw new Error(`not sortable type: ${valueA} or ${valueB}`);
+          }
+        });
+      case SortOrder.DESC:
+        return [...countries].sort((a, b) => {
+          const valueA = getSortValue(a);
+          const valueB = getSortValue(b);
+
+          if (typeof valueA === 'number' && typeof valueB === 'number') {
+            return valueB - valueA;
+          } else if (typeof valueA === 'string' && typeof valueB === 'string') {
+            return valueA === valueB ? 0 : valueA < valueB ? 1 : -1;
+          } else {
+            throw new Error(`not sortable type: ${valueA} or ${valueB}`);
+          }
+        });
+    }
+  }
+);
 
 /** 현재 페이지까지의 국가 정보 객체를 배열로 반환하는 selector */
-export const countriesSelector = createSelector(
-  allCountriesSelector,
+const countriesWithLimitSelector = createSelector(
+  sortedCountriesSelector,
   currentPageSelector,
-  (allCountries, currentPage) =>
-    allCountries.slice(0, currentPage * COUNTRY_LIMIT)
+  (countries, currentPage) => countries.slice(0, currentPage * COUNTRY_LIMIT)
+);
+
+/** 국가 리스트를 렌더링 가능한 객체의 배열로 나타내는 selector */
+export const renderableCountriesSelector = createSelector(
+  countriesWithLimitSelector,
+  (countries) =>
+    countries.map((country) => ({ ...country, key: country.alpha2Code }))
 );
 
 /** 다음 페이지의 국가 리스트가 존재하는 지 나타내는 selector */
 export const hasMoreCountriesSelector = createSelector(
-  allCountriesSelector,
+  countriesSelector,
   currentPageSelector,
-  (allCountries, currentPage) =>
-    currentPage * COUNTRY_LIMIT < allCountries.length
+  (countries, currentPage) => currentPage * COUNTRY_LIMIT < countries.length
 );
+
+/** country 객체의 올바른 속성임을 단언한다 */
+function assertIsValidCountryKey(
+  country: Country,
+  key: string
+): asserts key is keyof Country {
+  if (!Object.prototype.hasOwnProperty.call(country, key)) {
+    throw new Error(`국가 객체에 올바르지 않는 key로 접근하였습니다: ${key}`);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,10 @@ export interface APIResult<T> {
   errorMessage: string;
 }
 
+/**********************
+ * 유틸 타입
+ **********************/
+
 /** saga의 call effect에 사용된 함수가 Promise를 반환할 경우 Promise의 resolved된 타입을 반환한다 */
 export type CallReturnType<
   T extends (...args: unknown[]) => unknown

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -1,0 +1,6 @@
+/** enum 객체의 길이를 반환한다 */
+export function getEnumLength(
+  enumObject: Record<string, string | number>
+): number {
+  return Object.keys(enumObject).filter((key) => isNaN(Number(key))).length;
+}


### PR DESCRIPTION
# 요약
각 필드 별 정렬 기능 구현

## PR 상세
## 1) 작동 상세
테이블의 헤더를 클릭해서 해당되는 필드를 기준으로 정렬 순서를 변경합니다. 정렬 순서는 다음과 같이 3가지로 구성됩니다
* 기본: api 응답으로 받은 기본 순서
* 오름차
* 내림차

필드를 클릭할 때 기본 -> 오름차 -> 내림차 -> 기본 -> ... 을 반복합니다.
정렬을 할 경우 현재 페이지가 초기화 되어 첫 번째 페이지로 돌아갑니다.
하나의 필드가 정렬되면 다른 필드의 정렬은 초기화 됩니다. 즉, 이중 정렬이 불가능합니다.
country 객체는 다음과 같이 구성되어 있습니다
```ts
interface Country {
  name: string;
  alpha2Code: string;
  callingCodes: string[];
  capital: string;
  region: string;
}
```
`callingCodes` 속성은 배열이기 때문에 정렬을 수행할 때 길이를 기준으로 정렬을 수행합니다(src/state/selector.ts에서 확인 가능)

## 2) Table 컴포넌트 스타일 변경
테이블 셀의 최대 크기를 설정하고, 텍스트가 넘칠 경우 생략 기호(ellipsis, ...)를 추가하도록 변경하였습니다.