### PR TITLE
삭제 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const Header = styled.div`
 `;
 
 const Content = styled.div`
-  width: 1100px;
+  width: 1320px;
   margin: 0 auto;
 `;
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,19 +12,19 @@ export interface TableColumn {
   /** 컬럼의 이름 */
   title: string;
   /** 컬럼에 해당되는 data의 속성 */
-  dataIndex: string;
+  dataIndex?: string;
   /** 컬럼을 고유하게 식별하는 값. key가 없을 경우 dataIndex를 사용 */
   key?: string | number;
   /** data[dataIndex]를 값으로 받아 렌더링을 수행하는 함수 */
-  render?: (dataValue: unknown) => React.ReactNode;
+  render?: (data: TableData) => React.ReactNode;
   /** 컬럼이 클릭되었을 때 실행할 콜백 함수 */
   onClick?: (column: TableColumn) => void;
 }
 
-interface TableData {
+export interface TableData {
   /** data를 고유하게 식별하는 값 */
-  key: string | number;
-  [property: string]: React.ReactNode;
+  id: string;
+  [dataIndex: string]: React.ReactNode;
 }
 
 /** 테이블 컴포넌트 */
@@ -33,11 +33,11 @@ const Table = ({ columns, dataSource }: TableProps): JSX.Element => {
     <TableWrapper>
       <TableHeader>
         <TabularRow>
-          {columns.map((column) => {
-            const { title, key, dataIndex, onClick } = column;
+          {columns.map((column, index) => {
+            const { title, key, onClick } = column;
             return (
               <TabularHeader
-                key={key || dataIndex}
+                key={key || index}
                 clickable={!!onClick}
                 onClick={() => onClick && onClick(column)}
               >
@@ -49,10 +49,11 @@ const Table = ({ columns, dataSource }: TableProps): JSX.Element => {
       </TableHeader>
       <TableBody>
         {dataSource.map((data) => (
-          <TabularRow key={data.key}>
-            {columns.map(({ dataIndex, render }) => (
-              <TabularData key={dataIndex}>
-                {render ? render(data[dataIndex]) : data[dataIndex]}
+          <TabularRow key={data.id}>
+            {columns.map(({ dataIndex, render }, index) => (
+              <TabularData key={index}>
+                {render && render(data)}
+                {!render && dataIndex && data[dataIndex]}
               </TabularData>
             ))}
           </TabularRow>

--- a/src/containers/CountryTable.tsx
+++ b/src/containers/CountryTable.tsx
@@ -1,23 +1,36 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Table, { TableColumn } from '../components/Table';
+import Table, { TableColumn, TableData } from '../components/Table';
 import { SORT_ORDER_TEXT } from '../constant';
 import { actions, SortOptions } from '../state';
 import {
-  renderableCountriesSelector,
+  countriesWithLimitSelector,
   sortOptionsSelector,
 } from '../state/selector';
+import { assertIsDefined } from '../utils/assert';
 
 const { useEffect, useCallback } = React;
 
 /** 국가 정보를 나타내는 컴포넌트 */
 const CountryTable = (): JSX.Element => {
   const dispatch = useDispatch();
-  const countries = useSelector(renderableCountriesSelector);
+  const countries = useSelector(countriesWithLimitSelector);
   const sortOptions = useSelector(sortOptionsSelector);
 
   const onColumnClick = useCallback(
-    (column: TableColumn) => dispatch(actions.sortCountries(column.dataIndex)),
+    ({ dataIndex }: TableColumn) => {
+      assertIsDefined(dataIndex);
+      dispatch(actions.sortCountries(dataIndex));
+    },
+    [dispatch]
+  );
+
+  const removeCountry = useCallback(
+    ({ target }: React.MouseEvent) => {
+      if (target instanceof HTMLElement && target.dataset.id) {
+        dispatch(actions.removeCountry(target.dataset.id));
+      }
+    },
     [dispatch]
   );
 
@@ -35,9 +48,9 @@ const CountryTable = (): JSX.Element => {
     {
       title: getColumnTitle('callingCodes', sortOptions),
       dataIndex: 'callingCodes',
-      render: (codes: unknown) => {
-        if (Array.isArray(codes)) {
-          return codes.join(', ');
+      render: (data: TableData) => {
+        if (Array.isArray(data.callingCodes)) {
+          return data.callingCodes.join(', ');
         }
       },
       onClick: onColumnClick,
@@ -51,6 +64,16 @@ const CountryTable = (): JSX.Element => {
       title: getColumnTitle('region', sortOptions),
       dataIndex: 'region',
       onClick: onColumnClick,
+    },
+    {
+      title: 'Actions',
+      render: function render({ id }: TableData) {
+        return (
+          <button data-id={id} onClick={removeCountry}>
+            삭제
+          </button>
+        );
+      },
     },
   ];
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -26,6 +26,9 @@ export const actions = {
     payload: key,
   })),
   setSearchKeyword: createAction<string>('setSearchKeyword'),
+  removeCountry: createAction('removeCountry', (id: string) => ({
+    payload: id,
+  })),
   fetchCountries: createAction('fetchCountries'),
   search: createAction<string>('search'),
 };
@@ -67,6 +70,10 @@ const reducer = createReducer(INITIAL_STATE, (builder) => {
       const keyword = action.payload;
       state.searchKeyword = keyword;
       state.currentPage = INITIAL_PAGE;
+    })
+    .addCase(actions.removeCountry, (state, action) => {
+      const id = action.payload;
+      state.countries = state.countries.filter((country) => country.id !== id);
     });
 });
 

--- a/src/state/selector.ts
+++ b/src/state/selector.ts
@@ -67,17 +67,13 @@ const sortedCountriesSelector = createSelector(
 );
 
 /** 현재 페이지까지의 국가 정보 객체를 배열로 반환하는 selector */
-const countriesWithLimitSelector = createSelector(
+export const countriesWithLimitSelector = createSelector(
   sortedCountriesSelector,
   currentPageSelector,
-  (countries, currentPage) => countries.slice(0, currentPage * COUNTRY_LIMIT)
-);
-
-/** 국가 리스트를 렌더링 가능한 객체의 배열로 나타내는 selector */
-export const renderableCountriesSelector = createSelector(
-  countriesWithLimitSelector,
-  (countries) =>
-    countries.map((country) => ({ ...country, key: country.alpha2Code }))
+  (countries, currentPage) =>
+    countries
+      .map((country) => ({ ...country }))
+      .slice(0, currentPage * COUNTRY_LIMIT)
 );
 
 /** 다음 페이지의 국가 리스트가 존재하는 지 나타내는 selector */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface Country {
+  id: string;
   name: string;
   alpha2Code: string;
   callingCodes: string[];

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,3 +1,4 @@
+import { nanoid } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { APIResult, Country } from '../types';
 
@@ -10,9 +11,9 @@ export function getCountries(): Promise<APIResult<Country[]>> {
     url:
       'https://restcountries.eu/rest/v2/all?fields=alpha2Code;capital;name;region;callingCodes',
   })
-    .then(({ data }) => ({
+    .then(({ data }: { data: Country[] }) => ({
       isSuccess: true,
-      data,
+      data: data.map((item) => ({ ...item, id: nanoid() })),
       errorMessage: '',
     }))
     .catch((error) => ({


### PR DESCRIPTION
# 요약
row를 삭제할 수 있는 기능 추가

# PR 상세
## 1) Country 인터페이스에 id 속성 추가
id를 이용해 삭제할 수 있도록 Country에 id 속성을 추가하였습니다. id는 api.ts 유틸에서 nanoid 라이브러리를 이용해 추가합니다.
```ts
export interface Country {
  id: string; // 추가
  name: string;
  alpha2Code: string;
  callingCodes: string[];
  capital: string;
  region: string;
}
```
country 객체가 유니크한 속성을 가지므로 selector.ts의 renderableCountriesSelector 함수를 삭제할 수 있었습니다.
또한 Table 컴포넌트가 dataSource의 key 속성 대신 id를 사용할 수 있도록 변경하였습니다.

## 2) 삭제 기능 구현
Table에서 삭제 버튼을 추가할 수 있도록 TableProps 인터페이스 등을 변경하였습니다.
- Table 컴포넌트의 TableColume 타입의 dataIndex를 optional로 변경
- dataIndex와 render의 유무에 따를 조건부 렌더링 로직 변경
- render 함수에 dataValue가 아닌 data를 인자로 넣어주도록 변경